### PR TITLE
Added initial setup for the trip service

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -44,32 +44,32 @@ k8s_resource('api-gateway', port_forwards=8081,
 
 # Uncomment once we have a trip service
 
-#trip_compile_cmd = 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/trip-service ./services/trip-service/cmd/main.go'
-#if os.name == 'nt':
-#  trip_compile_cmd = './infra/development/docker/trip-build.bat'
+trip_compile_cmd = 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/trip-service ./services/trip-service/cmd/main.go'
+if os.name == 'nt':
+ trip_compile_cmd = './infra/development/docker/trip-build.bat'
 
-# local_resource(
-#   'trip-service-compile',
-#   trip_compile_cmd,
-#   deps=['./services/trip-service', './shared'], labels="compiles")
+local_resource(
+  'trip-service-compile',
+  trip_compile_cmd,
+  deps=['./services/trip-service', './shared'], labels="compiles")
 
-# docker_build_with_restart(
-#   'ride-sharing/trip-service',
-#   '.',
-#   entrypoint=['/app/build/trip-service'],
-#   dockerfile='./infra/development/docker/trip-service.Dockerfile',
-#   only=[
-#     './build/trip-service',
-#     './shared',
-#   ],
-#   live_update=[
-#     sync('./build', '/app/build'),
-#     sync('./shared', '/app/shared'),
-#   ],
-# )
+docker_build_with_restart(
+  'ride-sharing/trip-service',
+  '.',
+  entrypoint=['/app/build/trip-service'],
+  dockerfile='./infra/development/docker/trip-service.Dockerfile',
+  only=[
+    './build/trip-service',
+    './shared',
+  ],
+  live_update=[
+    sync('./build', '/app/build'),
+    sync('./shared', '/app/shared'),
+  ],
+)
 
-# k8s_yaml('./infra/development/k8s/trip-service-deployment.yaml')
-# k8s_resource('trip-service', resource_deps=['trip-service-compile'], labels="services")
+k8s_yaml('./infra/development/k8s/trip-service-deployment.yaml')
+k8s_resource('trip-service', resource_deps=['trip-service-compile'], labels="services")
 
 ### End of Trip Service ###
 ### Web Frontend ###

--- a/services/trip-service/README.md
+++ b/services/trip-service/README.md
@@ -1,0 +1,53 @@
+# trip service
+
+This service handles all trip-related operations in the system.
+
+## Architecture
+
+The service follows Clean Architecture principles with the following structure:
+
+```
+services/trip-service/
+├── cmd/                    # Application entry points
+│   └── main.go            # Main application setup
+├── internal/              # Private application code
+│   ├── domain/           # Business domain models and interfaces
+│   ├── service/          # Business logic implementation
+│   │   └── service.go    # Service implementations
+│   └── infrastructure/   # External dependencies implementations (abstractions)
+│       ├── events/       # Event handling (RabbitMQ)
+│       ├── grpc/         # gRPC server handlers
+│       └── repository/   # Data persistence
+├── pkg/                  # Public packages
+│   └── types/           # Shared types and models
+└── README.md            # This file
+```
+
+### Layer Responsibilities
+
+1. **Domain Layer** (`internal/domain/`)
+   - Contains business domain interfaces
+   - Defines contracts for repositories and services
+   - Pure business logic, no implementation details
+
+2. **Service Layer** (`internal/service/`)
+   - Implements business logic
+   - Uses repository interfaces
+   - Coordinates between different parts of the system
+
+3. **Infrastructure Layer** (`internal/infrastructure/`)
+   - `repository/`: Implements data persistence
+   - `events/`: Handles event publishing and consuming
+   - `grpc/`: Handles gRPC communication
+
+4. **Public Types** (`pkg/types/`)
+   - Contains shared types and models
+   - Can be imported by other services
+
+## Key Benefits
+
+1. **Dependency Inversion**: Services depend on interfaces, not implementations
+2. **Separation of Concerns**: Each layer has a specific responsibility
+3. **Testability**: Easy to mock dependencies for testing
+4. **Maintainability**: Clear boundaries between components
+5. **Flexibility**: Easy to swap implementations without affecting business logic

--- a/services/trip-service/cmd/main.go
+++ b/services/trip-service/cmd/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"log"
+	"ride-sharing/services/trip-service/internal/domain"
+	"ride-sharing/services/trip-service/internal/infrastructure/repository"
+	"ride-sharing/services/trip-service/internal/service"
+	"time"
+)
+
+func main() {
+
+	ctx := context.Background()
+	inmemRepo := repository.NewInMemRepository()
+
+	svc := service.NewService(inmemRepo)
+
+	fare := &domain.RideFareModel{
+		UserID: "42",
+	}
+	t, err := svc.CreateTrip(ctx, fare)
+
+	if err != nil {
+		log.Println(err)
+	}
+	log.Println(t)
+
+	// keep
+	for {
+		time.Sleep(time.Second)
+	}
+}

--- a/services/trip-service/internal/domain/ride_fare.go
+++ b/services/trip-service/internal/domain/ride_fare.go
@@ -1,0 +1,15 @@
+package domain
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type RideFareModel struct {
+	ID                primitive.ObjectID
+	UserID            string
+	PackageSlug       string // e.g. van, laxury, sedan
+	TotalPriceInCents float64
+	ExpiresAt         time.Time
+}

--- a/services/trip-service/internal/domain/trip.go
+++ b/services/trip-service/internal/domain/trip.go
@@ -1,0 +1,22 @@
+package domain
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type TripModel struct {
+	ID        primitive.ObjectID
+	UserID    string
+	Status    string
+	RiderFare *RideFareModel
+}
+
+type TripRepository interface {
+	CreateTrip(ctx context.Context, trip *TripModel) (*TripModel, error)
+}
+
+type TripService interface {
+	CreateTrip(ctx context.Context, fare RideFareModel) (*TripModel, error)
+}

--- a/services/trip-service/internal/infrastructure/repository/inmem.go
+++ b/services/trip-service/internal/infrastructure/repository/inmem.go
@@ -1,0 +1,24 @@
+package repository
+
+import (
+	"context"
+	"ride-sharing/services/trip-service/internal/domain"
+)
+
+type inmemRepository struct {
+	trips     map[string]*domain.TripModel
+	rideFares map[string]*domain.RideFareModel
+}
+
+func NewInMemRepository() *inmemRepository {
+	return &inmemRepository{
+		trips:     make(map[string]*domain.TripModel),
+		rideFares: make(map[string]*domain.RideFareModel),
+	}
+}
+
+func (r *inmemRepository) CreateTrip(ctx context.Context, trip *domain.TripModel) (*domain.TripModel, error) {
+
+	r.trips[trip.ID.Hex()] = trip // convert to hex to get the string representation
+	return trip, nil
+}

--- a/services/trip-service/internal/service/service.go
+++ b/services/trip-service/internal/service/service.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"context"
+	"ride-sharing/services/trip-service/internal/domain"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type service struct {
+	repo domain.TripRepository
+}
+
+func NewService(repo domain.TripRepository) *service {
+	return &service{
+		repo: repo,
+	}
+}
+
+func (s *service) CreateTrip(ctx context.Context, fare *domain.RideFareModel) (*domain.TripModel, error) {
+
+	t := &domain.TripModel{
+		ID:        primitive.NewObjectID(),
+		UserID:    fare.UserID,
+		Status:    "pending",
+		RiderFare: fare,
+	}
+	return s.repo.CreateTrip(ctx, t)
+}


### PR DESCRIPTION
This pull request introduces the initial implementation of the trip service, following Clean Architecture principles. The main changes include enabling the trip service in the development environment, adding a comprehensive README, and providing the foundational code for the domain, service, and repository layers. The service is designed for extensibility, maintainability, and testability.

**Trip Service Enablement & Documentation**

* Enabled the trip service build and deployment in the `Tiltfile`, allowing local development and Kubernetes resource management for the service.
* Added a detailed `README.md` for `trip-service` describing its architecture, directory structure, and layer responsibilities.

**Domain Layer Implementation**

* Defined core domain models and interfaces in `internal/domain/ride_fare.go` and `internal/domain/trip.go`, including `RideFareModel`, `TripModel`, `TripRepository`, and `TripService` interfaces. [[1]](diffhunk://#diff-8defce30dc58118d9d8303f48a591acfd13997f9782462cd5a7b56a46c791047R1-R15) [[2]](diffhunk://#diff-f39b0828f0daf8c94bbb815e37ea18a4f49c18f1d22cc8c01a8fc2ac7a92e746R1-R22)

**Service & Repository Layers**

* Implemented an in-memory repository (`internal/infrastructure/repository/inmem.go`) for storing trips and ride fares, and provided the `CreateTrip` method.
* Implemented the service layer (`internal/service/service.go`) with business logic for creating trips, utilizing the repository interface.

**Application Entry Point**

* Added the application entry point (`cmd/main.go`) that sets up the service, repository, and demonstrates creating a trip using the defined architecture.