### PR TITLE
Feat/2 api gateway

### DIFF
--- a/services/api-gateway/http.go
+++ b/services/api-gateway/http.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"log"
 	"net/http"
 	"ride-sharing/shared/contracts"
 )
@@ -13,7 +16,7 @@ func handleTripPreview(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to parse JSON data", http.StatusBadRequest)
 		return
 	}
-	// TODO: call trip service
+
 	defer r.Body.Close()
 
 	// validation
@@ -21,8 +24,24 @@ func handleTripPreview(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user id is required", http.StatusBadRequest)
 		return
 	}
+	jsonBody, _ := json.Marshal(reqBody)
+	reader := bytes.NewReader(jsonBody)
 
-	response := contracts.APIResponse{Data: "ok"}
+	resp, err := http.Post("http://trip-service:8083/preview", "application/json", reader)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	log.Println(resp)
+	fmt.Println("here...")
+	defer resp.Body.Close()
+
+	var respBody any
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		http.Error(w, "failed to parse response", http.StatusBadRequest)
+		return
+	}
+	response := contracts.APIResponse{Data: respBody}
 
 	writeJSON(w, http.StatusCreated, response)
 }

--- a/services/api-gateway/http.go
+++ b/services/api-gateway/http.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"ride-sharing/shared/contracts"
+)
+
+func handleTripPreview(w http.ResponseWriter, r *http.Request) {
+
+	var reqBody previewTripRequest
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		http.Error(w, "Failed to parse JSON data", http.StatusBadRequest)
+		return
+	}
+	// TODO: call trip service
+	defer r.Body.Close()
+
+	// validation
+	if reqBody.UserID == "" {
+		http.Error(w, "user id is required", http.StatusBadRequest)
+		return
+	}
+
+	response := contracts.APIResponse{Data: "ok"}
+
+	writeJSON(w, http.StatusCreated, response)
+}

--- a/services/api-gateway/json.go
+++ b/services/api-gateway/json.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func writeJSON(w http.ResponseWriter, status int, data any) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	return json.NewEncoder(w).Encode(data)
+}

--- a/services/api-gateway/main.go
+++ b/services/api-gateway/main.go
@@ -14,10 +14,16 @@ var (
 func main() {
 	log.Println("Starting API Gateway")
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Hello from API Gateway"))
-	})
+	mux := http.NewServeMux()
 
-	http.ListenAndServe(httpAddr, nil)
+	mux.HandleFunc("POST /trip/preview", handleTripPreview)
+
+	server := &http.Server{
+		Addr:    httpAddr,
+		Handler: mux,
+	}
+
+	if err := server.ListenAndServe(); err != nil {
+		log.Printf("HTTP server error: %v", err)
+	}
 }

--- a/services/api-gateway/types.go
+++ b/services/api-gateway/types.go
@@ -1,0 +1,9 @@
+package main
+
+import "ride-sharing/shared/types"
+
+type previewTripRequest struct {
+	UserID      string
+	Pickup      types.Coordinate
+	Destination types.Coordinate
+}

--- a/services/api-gateway/types.go
+++ b/services/api-gateway/types.go
@@ -3,7 +3,7 @@ package main
 import "ride-sharing/shared/types"
 
 type previewTripRequest struct {
-	UserID      string
-	Pickup      types.Coordinate
-	Destination types.Coordinate
+	UserID      string           `json:"userID"`
+	Pickup      types.Coordinate `json:"pickup"`
+	Destination types.Coordinate `json:"destination"`
 }

--- a/services/trip-service/cmd/main.go
+++ b/services/trip-service/cmd/main.go
@@ -1,33 +1,27 @@
 package main
 
 import (
-	"context"
 	"log"
-	"ride-sharing/services/trip-service/internal/domain"
+	"net/http"
+	h "ride-sharing/services/trip-service/internal/infrastructure/http"
 	"ride-sharing/services/trip-service/internal/infrastructure/repository"
 	"ride-sharing/services/trip-service/internal/service"
-	"time"
 )
 
 func main() {
-
-	ctx := context.Background()
 	inmemRepo := repository.NewInMemRepository()
-
 	svc := service.NewService(inmemRepo)
+	mux := http.NewServeMux()
 
-	fare := &domain.RideFareModel{
-		UserID: "42",
+	httphandler := h.HttpHandler{Service: svc}
+
+	mux.HandleFunc("POST /preview", httphandler.HandleTripPreview)
+
+	server := &http.Server{
+		Addr:    ":8083",
+		Handler: mux,
 	}
-	t, err := svc.CreateTrip(ctx, fare)
-
-	if err != nil {
-		log.Println(err)
-	}
-	log.Println(t)
-
-	// keep
-	for {
-		time.Sleep(time.Second)
+	if err := server.ListenAndServe(); err != nil {
+		log.Printf("HTTP server error: %v", err)
 	}
 }

--- a/services/trip-service/internal/domain/trip.go
+++ b/services/trip-service/internal/domain/trip.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"ride-sharing/shared/types"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -18,5 +19,6 @@ type TripRepository interface {
 }
 
 type TripService interface {
-	CreateTrip(ctx context.Context, fare RideFareModel) (*TripModel, error)
+	CreateTrip(ctx context.Context, fare *RideFareModel) (*TripModel, error)
+	GetRoute(ctx context.Context, pickup, destination *types.Coordinate) (*types.OsrmApiResponse, error)
 }

--- a/services/trip-service/internal/infrastructure/http/http.go
+++ b/services/trip-service/internal/infrastructure/http/http.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"ride-sharing/services/trip-service/internal/domain"
+	"ride-sharing/shared/types"
+)
+
+type HttpHandler struct {
+	Service domain.TripService
+}
+
+type previewTripRequest struct {
+	UserID      string           `json:"userID"`
+	Pickup      types.Coordinate `json:"pickup"`
+	Destination types.Coordinate `json:"destination"`
+}
+
+func (s *HttpHandler) HandleTripPreview(w http.ResponseWriter, r *http.Request) {
+	var reqBody previewTripRequest
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		http.Error(w, "failed to parse json data", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+
+	t, err := s.Service.GetRoute(ctx, &reqBody.Pickup, &reqBody.Destination)
+	if err != nil {
+		log.Println(err)
+	}
+	writeJSON(w, http.StatusOK, t)
+
+}
+
+func writeJSON(w http.ResponseWriter, status int, data any) error {
+	w.Header().Set("content-Type", "application/json")
+	w.WriteHeader(status)
+	return json.NewEncoder(w).Encode(data)
+}

--- a/services/trip-service/internal/service/service.go
+++ b/services/trip-service/internal/service/service.go
@@ -2,7 +2,12 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"ride-sharing/services/trip-service/internal/domain"
+	"ride-sharing/shared/types"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -26,4 +31,29 @@ func (s *service) CreateTrip(ctx context.Context, fare *domain.RideFareModel) (*
 		RiderFare: fare,
 	}
 	return s.repo.CreateTrip(ctx, t)
+}
+
+func (s *service) GetRoute(ctx context.Context, pickup, destination *types.Coordinate) (*types.OsrmApiResponse, error) {
+
+	url := fmt.Sprintf("http://router.project-osrm.org/route/v1/driving/%f,%f;%f,%f?overview=full&geometries=geojson",
+		pickup.Latitude, pickup.Longitude,
+		destination.Latitude, destination.Longitude,
+	)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from OSRM API: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the response: %v", err)
+	}
+
+	var routeResp types.OsrmApiResponse
+	if err := json.Unmarshal(body, &routeResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	return &routeResp, nil
 }

--- a/shared/types/types.go
+++ b/shared/types/types.go
@@ -14,3 +14,13 @@ type Coordinate struct {
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
 }
+
+type OsrmApiResponse struct {
+	Routes []struct {
+		Distance float64 `json:"distance"`
+		Duration float64 `json:"duration"`
+		Geometry struct {
+			Coordinate [][]float64 `json:"coordinates"`
+		} `json:"geometry"`
+	} `json:"routes"`
+}


### PR DESCRIPTION
This pull request introduces a new "trip preview" API endpoint to the ride-sharing system, enabling clients to request a route preview between a pickup and destination. It adds HTTP handlers and request types to both the API Gateway and Trip Service, wires up inter-service communication, and implements logic to fetch route details from the OSRM API.

**API Gateway Enhancements**
- Added a `handleTripPreview` HTTP handler for the `POST /trip/preview` route, which validates input, forwards requests to the Trip Service, and returns the response in a standardized format. (`services/api-gateway/http.go`, `services/api-gateway/main.go`, `services/api-gateway/types.go`) [[1]](diffhunk://#diff-271e5529ab0f45d69d0911fd528ff7aae30797a2d2f8d4e07aaed067610c2d9eR1-R47) [[2]](diffhunk://#diff-d6b2381f48a76672a8c24ea5cbac8a67011e711954b7724cc7506f13675dc5e5R21-R53) [[3]](diffhunk://#diff-c4e0a20786de2232caddb363c161dccac96ad4a2344e2a9e92c6b7a048dbf319R1-R9)
- Introduced a reusable `writeJSON` helper for consistent JSON responses. (`services/api-gateway/json.go`)

**Trip Service Enhancements**
- Added an HTTP handler (`HandleTripPreview`) and request type for trip preview, exposing a `POST /preview` endpoint that calls the new route preview logic. (`services/trip-service/internal/infrastructure/http/http.go`, `services/trip-service/cmd/main.go`) [[1]](diffhunk://#diff-cfee9cb33e1ccfcf8bbd8200dc1967c7c20a8a16c4323fe22eb16047c113966cR1-R42) [[2]](diffhunk://#diff-ce960f73f862c3dd712b707e7acfca743e829a2a8fb72f5e674e0713dd3ba73fL4-R25)
- Implemented `GetRoute` in the service layer to fetch route details from the OSRM API, returning distance, duration, and geometry. (`services/trip-service/internal/service/service.go`, `services/trip-service/internal/domain/trip.go`) [[1]](diffhunk://#diff-404efe8cad40fc8f128f362bac06c6cc5aba417751d7ee43ea512534be9a8a97R35-R59) [[2]](diffhunk://#diff-f39b0828f0daf8c94bbb815e37ea18a4f49c18f1d22cc8c01a8fc2ac7a92e746L21-R23)

**Shared Types**
- Defined the `OsrmApiResponse` struct to model OSRM route API responses. (`shared/types/types.go`)

These changes collectively enable the system to preview trip routes using external routing data, laying the foundation for fare estimation and route visualization features.